### PR TITLE
Refractor README and sponsorship content

### DIFF
--- a/.github/workflows/sponsorship.yml
+++ b/.github/workflows/sponsorship.yml
@@ -1,22 +1,21 @@
-name: Sponsors Activity
+name: Generate Sponsors README
 on:
-  # Schedule updates (At minute 0 past every 12th hour)
-  schedule: [{ cron: "0 */12 * * *" }]
-  # Lines below let you run workflow manually with each commit
   workflow_dispatch:
-  push: { branches: ["master", "main", "metrics"] }
+  schedule:
+    - cron: 30 15 * * 0-6
+permissions:
+  contents: write
 jobs:
-  # https://github.com/lowlighter/metrics/blob/master/source/plugins/languages/README.md
-  language-activity-metrics:
+  deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: lowlighter/metrics@latest
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+
+      - name: Generate Sponsors 💖
+        uses: JamesIves/github-sponsors-readme-action@v1
         with:
-            filename: assets/metrics.plugin.sponsors.svg
-            token: ${{ secrets.METRICS_TOKEN }}
-            base: ""
-            plugin_sponsors: yes
-            plugin_sponsors_sections: goal, list
-            plugin_sponsors_past: yes
-            plugin_sponsors_title: "Sponsor Me"
-            plugin_sponsors_size: 12
+          token: ${{ secrets.METRICS_TOKEN }}
+          file: 'README.md'
+          active-only: false
+          template: '* [{{ name }}]({{ url }}) - {{ login }}'

--- a/README.md
+++ b/README.md
@@ -142,9 +142,6 @@
 | ![Achievements](assets/metrics.plugin.achievements.svg) | ![Recent Activity](assets/metrics.plugin.habits.charts.svg) |
 | Discussions | Reactions |
 | ![Discussions](assets/metrics.plugin.discussions.svg) | ![Reactions](assets/metrics.plugin.reactions.svg) |
-| Habits | Sponsorships |
-| ![Language Activity](assets/metrics.plugin.languages.activity.svg) | ![Sponsorships](assets/metrics.plugin.sponsors.svg) |
-
 </details>                     
 <br>
 
@@ -154,6 +151,8 @@
 
 #### *I have done significant contributions to the Open source community and you can support and motivate me to continue work and giving more to the open source space.*
 
+<!-- sponsors --><!-- sponsors -->
+
 <div align="center">
   <a href="https://github.com/sponsors/yashksaini-coder"><img src="https://img.shields.io/badge/sponsor-d5d5d5?style=for-the-badge&logo=GitHub-Sponsors&logoColor=480ca8" /></a>
   <a href="https://buymeacoffee.com/yashksaini"><img src="https://img.shields.io/badge/Buy_Me_A_Coffee-d5d5d5?style=for-the-badge&logo=buy-me-a-coffee&logoColor=480ca8" /></a>
@@ -161,6 +160,6 @@
 </div>
 <br>
 
-<img src="https://www.animatedimages.org/data/media/562/animated-line-image-0184.gif" width="1920" />
-
+<!-- <img src="https://www.animatedimages.org/data/media/562/animated-line-image-0184.gif" width="1920" />
+ -->
 

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@
 <!-- sponsors --><!-- sponsors -->
 
 <div align="center">
-  <a href="https://github.com/sponsors/yashksaini-coder"><img src="https://img.shields.io/badge/sponsor-d5d5d5?style=for-the-badge&logo=GitHub-Sponsors&logoColor=480ca8" /></a>
-  <a href="https://buymeacoffee.com/yashksaini"><img src="https://img.shields.io/badge/Buy_Me_A_Coffee-d5d5d5?style=for-the-badge&logo=buy-me-a-coffee&logoColor=480ca8" /></a>
+  <a href="https://github.com/sponsors/yashksaini-coder"><img src="https://img.shields.io/badge/sponsor-30363D?style=for-the-badge&logo=GitHub-Sponsors&logoColor=#EA4AAA" /></a>
+  <a href="https://buymeacoffee.com/yashksaini"><img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ffdd00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black" /></a>
   </a>
 </div>
 <br>

--- a/README.md
+++ b/README.md
@@ -151,7 +151,11 @@
 
 #### *I have done significant contributions to the Open source community and you can support and motivate me to continue work and giving more to the open source space.*
 
-<!-- sponsors --><!-- sponsors -->
+<div align="center">
+<!-- sponsors -->
+
+<!-- sponsors -->
+</div>
 
 <div align="center">
   <a href="https://github.com/sponsors/yashksaini-coder"><img src="https://img.shields.io/badge/sponsor-30363D?style=for-the-badge&logo=GitHub-Sponsors&logoColor=#EA4AAA" /></a>


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow and modifications to the `README.md` file to improve the sponsorship section and update the layout.

Updates to GitHub Actions workflow:

* [`.github/workflows/sponsorship.yml`](diffhunk://#diff-6378ce1b769422bac3849c00693e6569f13816e595bbb0331843e29822db7c40L1-R21): Renamed the workflow to "Generate Sponsors README," adjusted the schedule to run daily at 15:30, updated permissions to write contents, and changed the job to use the `JamesIves/github-sponsors-readme-action` to generate the sponsors section in the `README.md` file.

Modifications to `README.md` file:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L145-L147): Removed the "Language Activity" and "Sponsorships" sections from the metrics table.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L158-R168): Updated the sponsorship badges with new styles and colors, and commented out the animated line image.